### PR TITLE
Use RT64_SDL_WINDOW_VULKAN to guard X11 detection instead of adding a new define.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     option(RECOMP_FLATPAK "Configure the build for Flatpak compatibility." OFF)
-    option(LINUX_USE_WAYLAND "Use Wayland instead of legacy X11 on GNU/Linux" OFF)
 endif()
 
 # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
@@ -310,14 +309,11 @@ endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(SDL2 REQUIRED)
-    if (NOT LINUX_USE_WAYLAND)
+    if (NOT RT64_SDL_WINDOW_VULKAN)
         find_package(X11 REQUIRED)
     endif()
 
     add_compile_definitions("RT64_SDL_WINDOW_VULKAN")
-    if(LINUX_USE_WAYLAND)
-        add_compile_definitions("LINUX_USE_WAYLAND")
-    endif()
 
     # Generate icon_bytes.c from the app icon PNG.
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/icon_bytes.c ${CMAKE_CURRENT_BINARY_DIR}/icon_bytes.h
@@ -331,7 +327,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
 
     target_include_directories(Goemon64Recompiled PRIVATE ${SDL2_INCLUDE_DIRS})
 
-    if (NOT LINUX_USE_WAYLAND)
+    if (NOT RT64_SDL_WINDOW_VULKAN)
         message(STATUS "X11_FOUND = ${X11_FOUND}")
         message(STATUS "X11_Xrandr_FOUND = ${X11_Xrandr_FOUND}")
 	message(STATUS "X11_INCLUDE_DIR = ${X11_INCLUDE_DIR}")


### PR DESCRIPTION
This is needed to match how it was done in the end in N64 Modern Runtime and in rt64.