### PR TITLE
In the end, remove X11 detection and linking.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,9 +309,6 @@ endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(SDL2 REQUIRED)
-    if (NOT RT64_SDL_WINDOW_VULKAN)
-        find_package(X11 REQUIRED)
-    endif()
 
     add_compile_definitions("RT64_SDL_WINDOW_VULKAN")
 
@@ -326,16 +323,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     message(STATUS "SDL2_INCLUDE_DIRS = ${SDL2_INCLUDE_DIRS}")
 
     target_include_directories(Goemon64Recompiled PRIVATE ${SDL2_INCLUDE_DIRS})
-
-    if (NOT RT64_SDL_WINDOW_VULKAN)
-        message(STATUS "X11_FOUND = ${X11_FOUND}")
-        message(STATUS "X11_Xrandr_FOUND = ${X11_Xrandr_FOUND}")
-	message(STATUS "X11_INCLUDE_DIR = ${X11_INCLUDE_DIR}")
-	message(STATUS "X11_LIBRARIES = ${X11_LIBRARIES}")
-
-        target_include_directories(Goemon64Recompiled PRIVATE ${X11_INCLUDE_DIR} ${X11_Xrandr_INCLUDE_PATH})
-        target_link_libraries(Goemon64Recompiled PRIVATE ${X11_LIBRARIES} ${X11_Xrandr_LIB})
-    endif()
 
     find_package(Freetype REQUIRED)
 


### PR DESCRIPTION
SDL2 abstracts the windowing system, directly poking X11 is not needed.