### PR TITLE
Add recomp_printf implementation and related exports

### DIFF
--- a/patches/misc_funcs.h
+++ b/patches/misc_funcs.h
@@ -1,0 +1,15 @@
+#ifndef __RECOMP_FUNCS_H__
+#define __RECOMP_FUNCS_H__
+
+#include "patch_helpers.h"
+
+DECLARE_FUNC(void, recomp_load_overlays, u32 rom, void* ram, u32 size);
+DECLARE_FUNC(void, recomp_puts, const char* data, u32 size);
+DECLARE_FUNC(void, recomp_exit);
+DECLARE_FUNC(void, recomp_handle_quicksave_actions, OSMesgQueue* enter_mq, OSMesgQueue* exit_mq);
+DECLARE_FUNC(void, recomp_handle_quicksave_actions_main, OSMesgQueue* enter_mq, OSMesgQueue* exit_mq);
+DECLARE_FUNC(u16, recomp_get_pending_warp);
+DECLARE_FUNC(u32, recomp_get_pending_set_time);
+DECLARE_FUNC(s32, recomp_get_autosave_enabled);
+
+#endif

--- a/patches/patches.h
+++ b/patches/patches.h
@@ -52,5 +52,5 @@ static inline void* memcpy(void* s1, const void* s2, size_t n) {
     
     return (void*)s1;
 }
-
+int recomp_printf(const char* fmt, ...);
 #endif // PATCHES_H

--- a/patches/print.c
+++ b/patches/print.c
@@ -1,0 +1,26 @@
+#include "patches.h"
+#include "misc_funcs.h"
+
+// Manual definitions for variadic arguments since stdarg.h is not available
+typedef __builtin_va_list va_list;
+#define va_start(v, l) __builtin_va_start(v, l)
+#define va_end(v) __builtin_va_end(v)
+
+// Forward declaration of _Printf function
+int _Printf(void *(*put)(void *, const char *, size_t), void *arg, const char *fmt, va_list ap);
+
+void* proutPrintf(void* dst, const char* fmt, size_t size) {
+    recomp_puts(fmt, size);
+    return (void*)1;
+}
+
+RECOMP_EXPORT int recomp_printf(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+
+    int ret = _Printf(&proutPrintf, NULL, fmt, args);
+
+    va_end(args);
+
+    return ret;
+}

--- a/patches/syms.ld
+++ b/patches/syms.ld
@@ -30,3 +30,5 @@ osViSetMode_recomp = 0x8F000064;
 osViSwapBuffer_recomp = 0x8F000068;
 osWritebackDCacheAll_recomp = 0x8F00006C;
 sprintf_recomp = 0x8F000070;
+recomp_puts = 0x8F000074;
+recomp_exit = 0x8F000078;


### PR DESCRIPTION
Introduces recomp_printf as a variadic print function using a custom _Printf handler. Adds misc_funcs.h for function declarations, print.c for the implementation, and updates syms.ld with new symbol exports. Also updates patches.h to declare recomp_printf.